### PR TITLE
Added handler for komi GTP command; updated known_commands

### DIFF
--- a/michi.c
+++ b/michi.c
@@ -1283,8 +1283,8 @@ void begin_game(void) {
 void gtp_io(void)
 {
     char line[BUFLEN], *cmdid, *command, msg[BUFLEN], *ret;
-    char *known_commands="\ncputime\ndebug subcmd\ngenmove\nhelp\nknown_command"
-    "\nlist_commands\nname\nplay\nprotocol_version\nquit\nversion\n";
+    char *known_commands="\nboardsize\ncputime\ndebug subcmd\ngenmove\nhelp\nknown_command"
+    "\nkomi\nlist_commands\nname\nplay\nprotocol_version\nquit\nversion\n";
     int      game_ongoing=1, i;
     int      *owner_map=calloc(BOARDSIZE, sizeof(int));
     TreeNode *tree;
@@ -1359,6 +1359,19 @@ void gtp_io(void)
             if (size != N) {
                 sprintf(buf, "Error: Trying to set incompatible boardsize %s"
                              " (!= %d)", str, N);
+                log_fmt_s('E', buf, NULL);
+                ret = buf;
+            }
+            else
+                ret = "";
+        }
+        else if (strcmp(command, "komi") == 0) {
+            char *str = strtok(NULL, " \t\n");
+            if(str == NULL) goto finish_command;
+            float komi = (float) atof(str);
+            if (komi != 7.5) {
+                sprintf(buf, "Error: Trying to set incompatible boardsize %s"
+                             " (!= 7.5)", str);
                 log_fmt_s('E', buf, NULL);
                 ret = buf;
             }


### PR DESCRIPTION
Added `komi` and `boardsize` to list of known commands
Handler for `komi` will succeed for with komi of 7.5, return error otherwise

I was trying to test a group of engines and the controller would abort because `komi` wasn't being handled.  I noted that `boardsize` was handled very simply.  I used the same approach with `komi`.  The testing framework now works.
